### PR TITLE
Use config as source for footer links and logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,6 +67,34 @@ const config = {
           autoCollapseCategories: true,
         },
       },
+      footer: {
+        logo: {
+          alt: "OpenTF",
+          src: "img/nav-logo.svg",
+        },
+        links: [
+          {
+            label: "Manifesto",
+            href: "#",
+          },
+          {
+            label: "Supporters",
+            href: "#",
+          },
+          {
+            label: "FAQs",
+            href: "#",
+          },
+          {
+            label: "Blog",
+            href: "#",
+          },
+          {
+            label: "Docs",
+            href: "#",
+          },
+        ],
+      },
       navbar: {
         logo: {
           alt: "OpenTF",

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,16 +1,68 @@
 import React from "react";
-import NavLogo from "@site/static/img/nav-logo.svg";
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
+import ThemedImage from "@theme/ThemedImage";
+import { FooterLogo, FooterLinkItem } from "@docusaurus/theme-common";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
-export default function Footer() {
+type LogoImageProps = {
+  logo: FooterLogo;
+};
+
+function LogoImage({ logo }: LogoImageProps) {
+  const { withBaseUrl } = useBaseUrlUtils();
+  const sources = {
+    light: withBaseUrl(logo.src),
+    dark: withBaseUrl(logo.srcDark ?? logo.src),
+  };
   return (
-    <footer className="text-light2 flex flex-col md:flex-row items-center justify-between gap-6 w-full py-6 px-6 md:px-28">
-      <NavLogo />
+    <ThemedImage
+      alt={logo.alt}
+      sources={sources}
+      width={logo.width}
+      height={logo.height}
+      style={logo.style}
+    />
+  );
+}
+
+type LinkItemProps = {
+  item: FooterLinkItem;
+};
+
+function LinkItem({ item }: LinkItemProps) {
+  const { to, href, label, prependBaseUrlToHref, ...props } = item;
+  const toUrl = useBaseUrl(to);
+  const normalizedHref = useBaseUrl(href, { forcePrependBaseUrl: true });
+  return (
+    <Link
+      {...(href
+        ? {
+            href: prependBaseUrlToHref ? normalizedHref : href,
+          }
+        : {
+            to: toUrl,
+          })}
+      {...props}
+    >
+      {label}
+    </Link>
+  );
+}
+
+type FooterProps = {
+  logo: FooterLogo;
+  links: FooterLinkItem[];
+};
+
+export default function Footer({ logo, links }: FooterProps) {
+  return (
+    <footer className="text-light2 flex flex-col md:flex-row items-center justify-between gap-6 py-6 container mx-auto">
+      <LogoImage logo={logo} />
       <div className="flex flex-row gap-6 align-center">
-        <a className="cursor-pointer">Manifesto</a>
-        <a className="cursor-pointer">Supporters</a>
-        <a className="cursor-pointer">FAQs</a>
-        <a className="cursor-pointer">Blog</a>
-        <a className="cursor-pointer">Docs</a>
+        {links.map((link) => (
+          <LinkItem key={link.href ?? link.to} item={link} />
+        ))}
       </div>
       <div className="flex flex-row gap-6">
         <a className="cursor-pointer header-github-link" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,6 @@ export default function Home() {
       <HowToSupport />
       <HowToContribute />
       <LatestNews />
-      <Footer />
     </Layout>
   );
 }

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { useThemeConfig } from "@docusaurus/theme-common";
+
+import FooterComponent from "@site/src/components/Footer";
+
+function Footer() {
+  const { footer } = useThemeConfig();
+  if (!footer) {
+    return null;
+  }
+  return <FooterComponent logo={footer.logo} links={footer.links} />;
+}
+
+export default React.memo(Footer);


### PR DESCRIPTION
This PR converts our footer to a global component that'll be on each page automatically. The footer now will also take links and logo from the docusaurus theme so that we have one source of truth for these things.