### PR TITLE
Add Slack links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,8 +162,7 @@ const config = {
             className: "header-twitter-link",
           },
           {
-            // TODO: add actual slack link
-            href: "https://slack.com/",
+            href: "https://join.slack.com/t/slack-9uv6202/shared_invite/zt-22ifsm1t2-AF6cL0cOdzivP8E~4deDJA",
             position: "right",
             className: "header-slack-link",
           },

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -67,7 +67,10 @@ export default function Footer({ logo, links }: FooterProps) {
       <div className="flex flex-row gap-6">
         <a className="cursor-pointer header-github-link" />
         <a className="cursor-pointer header-twitter-link" />
-        <a className="cursor-pointer header-slack-link" />
+        <a
+          href="https://join.slack.com/t/slack-9uv6202/shared_invite/zt-22ifsm1t2-AF6cL0cOdzivP8E~4deDJA"
+          className="cursor-pointer header-slack-link"
+        />
       </div>
     </footer>
   );


### PR DESCRIPTION
FYI: footer will also use the `docusaurus.config.js` once a PR with text pages is merged.