### PR TITLE
Make docs a bit easier on the eyes

### DIFF
--- a/src/theme/DocItem/Content.tsx
+++ b/src/theme/DocItem/Content.tsx
@@ -43,6 +43,9 @@ const classNames = [
   "prose-h1:text-4xl",
   "prose-h2:text-3xl",
   "prose-h3:text-2xl",
+
+  "prose-th:px-3",
+  "prose-td:px-3",
 ];
 
 export default function DocItemContent({ children }) {


### PR DESCRIPTION
Closes #104

This PR fixes what's mentioned in the linked ticket. Basically making docs a bit easier on the eyes by increasing the contrast, and making sure elements like `<strong>`, `<a>` and `<code>` do not pop too much.