### PR TITLE
toc active item highlight

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -161,6 +161,7 @@ const config = {
         ],
       },
       navbar: {
+        hideOnScroll: true,
         items: [
           {
             to: "/manifesto",


### PR DESCRIPTION
In this PR we changed variable of nav header to improve scroll functionality which highlights item after the click on right sidebar navigation. Previously it calculated it wrong because docusarious thinks that our sticky nav has 24px (even it isn't visible) so either we can set `--ifm-navbar-height` variable to 24px to improve it or set this property `hideOnScroll` to `true`. I have choosen second option as it could have smaller impact on rest of behaviours in the app which base on `--ifm-navbar-height` 

closes #109