### PR TITLE
Simplify page titles

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: Documentation
 hide_table_of_contents: true
 ---
 

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -10,7 +10,7 @@ import Headline from "../components/Headline";
 
 export default function FAQ() {
   return (
-    <Layout title="OpenTofu FAQ">
+    <Layout title="FAQ">
       <Jumbotron>
         <Headline>Frequently Asked Questions</Headline>
       </Jumbotron>

--- a/src/pages/manifesto.tsx
+++ b/src/pages/manifesto.tsx
@@ -8,7 +8,7 @@ import Link from "@docusaurus/Link";
 export default function Manifesto() {
   return (
     <Layout
-      title="The OpenTofu Manifesto"
+      title="Manifesto"
       description="Terraform was open-sourced in 2014 under the Mozilla Public License
     (v2.0) (the “MPL”). Over the next ~9 years, it built up a community
     that included thousands of users, contributors, customers, certified

--- a/src/pages/supporters.tsx
+++ b/src/pages/supporters.tsx
@@ -24,7 +24,7 @@ export default function SupportersPage() {
   const isMoreButtonVisible = filteredSupporters.length > INITIAL_LIST_COUNT;
 
   return (
-    <Layout title="OpenTofu Supporters">
+    <Layout title="Supporters">
       <Jumbotron>
         <Headline>Supporters</Headline>
       </Jumbotron>


### PR DESCRIPTION
This PR simplifies page titles to mention OpenTofu just once (which comes from `title` in config).