### PR TITLE
make scrollIntoView more smooth

### DIFF
--- a/src/components/Accordion/Item.tsx
+++ b/src/components/Accordion/Item.tsx
@@ -59,7 +59,10 @@ const AccordionItem = ({
     if (!detailsRef.current.hasAttribute("open")) {
       // Push to end of queue to read updated position and scroll to it
       setTimeout(() => {
-        detailsRef.current.scrollIntoView({ behavior: "smooth" });
+        detailsRef.current.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
       });
     }
 


### PR DESCRIPTION
I've added `block: "nearest" ` to `scrollIntoView` to make scroll behavior less irritating. Now, the page doesn't scroll if there's no need for it.

