### PR TITLE
change size of code in sidebar

### DIFF
--- a/src/theme/TOC/index.tsx
+++ b/src/theme/TOC/index.tsx
@@ -14,7 +14,7 @@ export default function TOC({ className, ...props }: Props) {
       <TOCItems
         {...props}
         className="[&_ul]:pl-4"
-        linkClassName="py-2 px-4 block hover:text-brand-700 dark:hover:text-brand-600 [&.active]:bg-brand-500 [&.active]:dark:bg-brand-800 [&.active]:text-gray-900 [&.active]:dark:text-brand-600"
+        linkClassName="py-2 px-4 block hover:text-brand-700 dark:hover:text-brand-600 [&.active]:bg-brand-500 [&.active]:dark:bg-brand-800 [&.active]:text-gray-900 [&.active]:dark:text-brand-600 [&_code]:text-sm"
         linkActiveClassName="active"
       />
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before:
<img width="203" alt="Screenshot 2023-09-20 at 15 47 46" src="https://github.com/opentofu/opentofu.org/assets/125285541/4d253ebb-22b0-417d-a845-4809cfb643e9">
<img width="206" alt="Screenshot 2023-09-20 at 15 47 50" src="https://github.com/opentofu/opentofu.org/assets/125285541/37f56d0e-3327-42c7-b4a5-acc273178984">

After:
<img width="275" alt="Screenshot 2023-09-20 at 15 47 12" src="https://github.com/opentofu/opentofu.org/assets/125285541/aa917f4d-7109-406a-871a-5fc50fdfd543">
<img width="278" alt="Screenshot 2023-09-20 at 15 47 21" src="https://github.com/opentofu/opentofu.org/assets/125285541/fcb237e3-5384-449f-80f5-aeb987939a59">


<!--- Describe your changes in detail -->

## Motivation and Context
Font size for code in right sidebar seems to be too big and for hover effect the underline looks buggy
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
