### PR TITLE
add nofollow to supporter links

### DIFF
--- a/src/components/SupportersList/index.tsx
+++ b/src/components/SupportersList/index.tsx
@@ -20,7 +20,7 @@ export default function SupportersList({ list }: SupportersListProps) {
           <Link
             href={supporter.url}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener noreferrer nofollow"
             className="w-1/3 text-inherit font-bold text-gray-900 hover:text-brand-700 dark:text-gray-100 dark:hover:text-brand-500"
             aria-label={`Go to ${supporter.name} website`}
           >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds `rel="nofollow"` attribute to external links in supporters list for SEO purposes. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
