### PR TITLE
add empty line when generating supporters.json

### DIFF
--- a/sync-supporters.js
+++ b/sync-supporters.js
@@ -22,7 +22,7 @@ async function sync() {
 
   fs.writeFileSync(
     "./supporters.json",
-    JSON.stringify(supporters, null, 2),
+    JSON.stringify(supporters, null, 2) + "\n",
     "utf8",
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We have an [empty git commit error](https://github.com/opentofu/opentofu.org/actions/runs/6271263368/job/17030537566#step:6:76) produced by `lint-staged` in our sync supporters cron workflow. The reason is that we don't add empty line when generating the file, then lint-staged adds this and then throws error that there's no changes. So if we add empty line during the generation phase, we'll see no error as the GH action will not try to execute commit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<img width="1257" alt="Screenshot 2023-09-22 at 10 39 36" src="https://github.com/opentofu/opentofu.org/assets/7979992/68a53f2f-d856-43c5-bf97-6d3aa2136a8c">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
