### PR TITLE
Fix blog post's authors section on mobile resolutions

### DIFF
--- a/src/theme/BlogPostItem/Header/Author/index.tsx
+++ b/src/theme/BlogPostItem/Header/Author/index.tsx
@@ -14,9 +14,9 @@ export default function BlogPostItemHeaderAuthor({ author }: Props) {
   const { name, title, url, imageURL, email } = author;
   const link = url || (email && `mailto:${email}`) || undefined;
   return (
-    <div className="flex gap-4 items-center shrink-0">
+    <div className="flex gap-4 items-center">
       {imageURL && (
-        <MaybeLink href={link}>
+        <MaybeLink href={link} className="shrink-0">
           <img src={imageURL} alt={name} className="w-14 h-14 rounded-full" />
         </MaybeLink>
       )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A small fix that wraps the text (author's title) if there's not enough space. Previously it would just stay on the same line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
