### PR TITLE
Fix Slack URL

### DIFF
--- a/blog/2023-09-05-the-opentofu-fork-is-now-available.md
+++ b/blog/2023-09-05-the-opentofu-fork-is-now-available.md
@@ -28,7 +28,7 @@ A key part of working in the open is making our roadmap open. So here's a quick 
 - **Wait on HashiCorp's response**. We reached out to HashiCorp publicly and privately and requested a response by August 25th.
 - **Start working on the OpenTofu fork**. With no response from HashiCorp, we created the OpenTofu fork, and started working on it in private.
 - **Apply to join the Linux Foundation**. We want OpenTofu to be part of an impartial, community-driven foundation, so we submitted all the paperwork to join the Linux Foundation.
-- **Open up community Slack discussions**. We created the [OpenTofu Community Slack](https://communityinviter.com/apps/opentfcommunity/opentofu) to give the community a way to have discussions, provide feedback, ask questions, etc.
+- **Open up community Slack discussions**. We created the [OpenTofu Community Slack](/slack) to give the community a way to have discussions, provide feedback, ask questions, etc.
 - **Prepare the OpenTofu repo for collaboration**. Rename everything to OpenTofu; pick steering committee members; define [contribution guidelines](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md); get CI / CD and testing working; etc.
 - **Release the OpenTofu repo**. As per this announcement, we are making the OpenTofu repo public at [github.com/opentofu/opentofu](https://github.com/opentofu/opentofu)!
 
@@ -51,7 +51,7 @@ The response from the community so far has been incredible. In just a few weeks,
 
 This sort of growth is unprecedented, and we're humbled by all of your support. As per the roadmap in the previous section, we're working hard on getting OpenTofu to the point where we can start doing official releases.
 
-In the meantime, you can follow our progress at [github.com/opentofu/opentofu](https://github.com/opentofu/opentofu), contribute to the project by following the [contribution guidelines](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md), and provide feedback in the [OpenTofu Community Slack](https://communityinviter.com/apps/opentfcommunity/opentofu). We are thrilled to be working with the whole community in making OpenTofu a truly open, community-driven project!
+In the meantime, you can follow our progress at [github.com/opentofu/opentofu](https://github.com/opentofu/opentofu), contribute to the project by following the [contribution guidelines](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md), and provide feedback in the [OpenTofu Community Slack](/slack). We are thrilled to be working with the whole community in making OpenTofu a truly open, community-driven project!
 
 ### FAQ
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,10 +126,11 @@ const config = {
             to: "/blog/the-opentofu-fork-is-now-available",
             from: "/fork",
           },
-          {
-            to: "https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w",
-            from: "/slack",
-          },
+          // TODO: This will be possible after upgrading to Docusaurus 3
+          // {
+          //   to: "https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w",
+          //   from: "/slack",
+          // },
         ],
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,6 +126,10 @@ const config = {
             to: "/blog/the-opentofu-fork-is-now-available",
             from: "/fork",
           },
+          {
+            to: "https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w",
+            from: "/slack",
+          },
         ],
       },
     ],
@@ -256,7 +260,7 @@ const config = {
           },
           {
             type: "custom-social-icon-link-navbar-item",
-            href: "https://communityinviter.com/apps/opentfcommunity/opentofu",
+            href: "/slack",
             position: "right",
             name: "slack",
             label: "Join us on Slack",

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -58,7 +58,7 @@ export default function Footer({ links }: FooterProps) {
         />
         <SocialIconLink
           name="slack"
-          href="https://communityinviter.com/apps/opentfcommunity/opentofu"
+          href="/slack"
           label="Join us on Slack"
           hiddenLabel
         />

--- a/src/components/HowToSupport/index.tsx
+++ b/src/components/HowToSupport/index.tsx
@@ -199,10 +199,7 @@ export default function HowToSupport() {
             }
           >
             6. Joining{" "}
-            <Link
-              href="https://communityinviter.com/apps/opentfcommunity/opentofu"
-              className="underline"
-            >
+            <Link href="/slack" className="underline">
               our Slack community
             </Link>{" "}
             &amp;{" "}

--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w"
+    />
+    <link
+      rel="canonical"
+      href="https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w"
+    />
+  </head>
+  <script>
+    window.location.href =
+      "https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w";
+  </script>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've added a `/slack` path that will always redirect to the latest Slack invite URL, this way we'll need to change it only in one place in the future if needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
