### PR TITLE
fix max-width on wide screens

### DIFF
--- a/src/components/TextContent/index.tsx
+++ b/src/components/TextContent/index.tsx
@@ -8,7 +8,7 @@ const classNames = [
   "dark:prose-invert",
   "lg:prose-lg",
 
-  "max-w-full",
+  "max-w-full md:max-w-prose",
 
   "text-gray-900",
   "dark:text-gray-100",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous PR fixed max-width for smaller screens, but apparently broke Manifesto page for wider screens. Here's a fix for that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
