### PR TITLE
Issue opentofu/opentofu#859: Redirecting old installation docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,6 +143,14 @@ const config = {
             to: "/blog/the-opentofu-fork-is-now-available",
             from: "/fork",
           },
+          {
+            from: "/docs/cli/install/apt",
+            to: "/docs/intro/install/apt",
+          },
+          {
+            from: "/docs/cli/install/yum",
+            to: "/docs/intro/install/yum",
+          },
           // TODO: This will be possible after upgrading to Docusaurus 3
           // {
           //   to: "https://join.slack.com/t/opentofucommunity/shared_invite/zt-24ma55j2u-a2DlPHCoMqlJkCEHL5DX_w",


### PR DESCRIPTION
## Description

This PR contains redirects for the content removed in opentofu/opentofu#859.

## Motivation and Context

Let's not break links :)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
