### PR TITLE
Adding build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+
+WORKDIR /work
+COPY package.json /work
+COPY package-lock.json /work
+RUN npm i
+
+CMD ["npm", "run", "start", "--", "--host","0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -8,29 +8,48 @@
 - TypeScript
 - Tailwind CSS
 
-## Getting Started
+## Working with this repository
 
-1. Clone the repository
+### Cloning the repository
+
+This repository uses git submodules to pull in the [main OpenTofu repository](https://github.com/opentofu/opentofu).
+You can clone it using the following two steps:
+
+1. Clone the repository:
 
 ```bash
 git clone git@github.com:opentofu/opentofu.org.git
 ```
 
-2. Install dependencies
-
-```bash
-npm i
-```
-
-3. Fetch the documentation
+2. Fetch the documentation:
 
 ```bash
 git submodule init
 git submodule update
 ```
 
-4. Start the development server
+### Running the dev server locally
+
+You can run the dev server if you have a local NodeJS/npm environment installed:
+
+1. Install dependencies:
+
+```bash
+npm i
+```
+
+2. Start the development server:
 
 ```bash
 npm run start
+```
+
+You can now access the site locally at http://localhost:3000/
+
+### Running the dev server in a container
+
+You can also run the dev server in a container with the following command:
+
+```bash
+docker compose up --build
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  website:
+    build: .
+    volumes:
+      - source: ./
+        target: /work
+        type: bind
+      - /work/node_modules
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Description

This commit adds a build container to make it easier for people without NodeJS/npm to run the website locally.

## Motivation and Context

Currently, running the dev server requires a local NodeJS/npm environment, which not everyone is comfortable with. This change along with #214 makes it easy to run a local dev environment.

## Types of changes

- [X] Ease of development
