### PR TITLE
Add simple registry landing page for OpenTofu/OpenTofu#942

### DIFF
--- a/src/pages/registry.tsx
+++ b/src/pages/registry.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Jumbotron from "../components/Jumbotron";
+import Link from "@docusaurus/Link";
+import Headline from "../components/Headline";
+import TextContent from "../components/TextContent";
+
+export default function FAQ() {
+  return (
+    <Layout title="Registry">
+      <Jumbotron>
+        <Headline>OpenTofu Registry</Headline>
+      </Jumbotron>
+      <TextContent className="mb-4 md:mb-10 mx-auto px-4">
+        The OpenTofu Registry contains providers and modules to be used with OpenTofu. In order to view the catalogue of providers / modules, or
+        if you’d like to submit new providers / modules, please head to <Link href="https://github.com/opentofu/registry/">https://github.com/opentofu/registry/</Link>.
+      </TextContent>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Fixes: OpenTofu/OpenTofu#942 (once @cube2222 puts the rewrite rule in place)

![image](https://github.com/opentofu/opentofu.org/assets/892136/6ba0b19b-189a-499b-ad0c-6c6a97a14563)
