### PR TITLE
Fix horizontal padding issue in tables

### DIFF
--- a/src/components/TextContent/index.tsx
+++ b/src/components/TextContent/index.tsx
@@ -53,8 +53,8 @@ const classNames = [
   "dark:prose-headings:text-gray-50",
 
   // <th>, <td>
-  "prose-th:px-3",
-  "prose-td:px-3",
+  "prose-th:!px-3",
+  "prose-td:!px-3",
 ];
 
 export default function TextContent({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #224

There's a specificity issue between dev and prod builds due to how Tailwind's styles are discovered. The simplest fix is to just force "our" styles as the TW's typography plugin does not allow disabling the default table styles.

I've checked links attached to the issue and they seem to work fine:
https://7d0bc05e.opentf-website.pages.dev/docs/language/syntax/json/
https://7d0bc05e.opentf-website.pages.dev/docs/language/expressions/strings/#quoted-strings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
