### PR TITLE
Add cd command before git submodules command under Fetch the documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ git clone git@github.com:opentofu/opentofu.org.git
 2. Fetch the documentation:
 
 ```bash
+cd opentofu.org
 git submodule init
 git submodule update
 ```


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Add cd command before git submodules command under Fetch the documentation section

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `Fetch the documentation` section doesn't include or mention changing into the cloned directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
