### PR TITLE
Fixes #242: Remove latest news section

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -4,9 +4,8 @@ import Hero from "../Hero";
 import Goals from "../Goals";
 import Supporters from "../Supporters";
 import FAQ from "../FAQ";
-import HowToSupport from "../HowToSupport";
 import HowToContribute from "../HowToContribute";
-import LatestNews, { RecentPost } from "../LatestNews";
+import { RecentPost } from "../LatestNews";
 
 type HomeProps = {
   recentPosts: RecentPost[];
@@ -20,8 +19,6 @@ export default function Home({ recentPosts }: HomeProps) {
       <HowToContribute />
       <FAQ />
       <Supporters />
-      <HowToSupport />
-      <LatestNews recentPosts={recentPosts} />
     </Layout>
   );
 }


### PR DESCRIPTION
## Description

Fixes #242: remove latest news section

## Motivation and Context

It's broken.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
