### PR TITLE
Added underline to distinguish hyperlinks inside the admonitions component

### DIFF
--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -120,7 +120,7 @@ export default function Admonition(props: Props) {
   return (
     <div
       className={clsx(
-        "flex flex-col py-2 px-3 not-prose border gap-1 [&+&]:mt-3 [&_a:hover]:text-gray-900 dark:[&_a:hover]:text-gray-50 [&_a>code]:font-bold [&_code]:text-base [&_code]:px-1.5",
+        "flex flex-col py-2 px-3 not-prose border gap-1 [&+&]:mt-3 [&_a:hover]:text-gray-900 dark:[&_a:hover]:text-gray-50 [&_a>code]:font-bold [&_code]:text-base [&_code]:px-1.5 [&_a]:underline",
         typeConfig.className,
       )}
       role="alert"


### PR DESCRIPTION
Added underline CSS to distinguish hyperlinks inside the admonitions component like warnings, notes


<!--- Provide a general summary of your changes in the Title above -->

## Description
Admonitions is a component set that is used to display warnings, notes and danger banners on the website.
## Motivation and Context
Fixes #223 

## Screenshots (if appropriate):

Before:

![Screenshot 2024-01-12 at 3 05 29 PM](https://github.com/opentofu/opentofu.org/assets/4549937/763eccaf-ae6e-4418-a086-2e9e0d9769b2)


After:
![Screenshot 2024-01-12 at 3 05 42 PM](https://github.com/opentofu/opentofu.org/assets/4549937/fd99d2ef-c1fe-4a6e-8d3f-8c613052eec1)

An example admonition hyperlink is located at `<root URL of website>/docs/cli/commands/login/`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
