### PR TITLE
Added margins to admonition paragraphs

### DIFF
--- a/src/theme/Admonition/index.tsx
+++ b/src/theme/Admonition/index.tsx
@@ -120,7 +120,7 @@ export default function Admonition(props: Props) {
   return (
     <div
       className={clsx(
-        "flex flex-col py-2 px-3 not-prose border gap-1 [&+&]:mt-3 [&_a:hover]:text-gray-900 dark:[&_a:hover]:text-gray-50 [&_a>code]:font-bold [&_code]:text-base [&_code]:px-1.5 [&_a]:underline",
+        "flex flex-col py-2 px-3 not-prose border gap-1 [&+&]:mt-3 [&_a:hover]:text-gray-900 dark:[&_a:hover]:text-gray-50 [&_a>code]:font-bold [&_code]:text-base [&_code]:px-1.5 [&_a]:underline [&_p]:mb-2",
         typeConfig.className,
       )}
       role="alert"


### PR DESCRIPTION

## Description
Admonitions is a Library that is used in the docs site to include notes, warnings and error messages. According to #222 there were no margins in the paragraphs. This PR aims to address that issue.

## Motivation and Context
Fixes #222 
In the current version opentofu documentation, there are no admonitions with a code block presently that would trigger this case, so to test it successfully add the following lines to any MDX page and then try viewing it:

````
:::warning
Test `padding` for code snippets.
```
bash

echo 'Hello World'
```
:::
````

## Screenshots (if appropriate):

Before: 
<img width="746" alt="Screenshot 2024-01-15 at 2 23 25 PM" src="https://github.com/opentofu/opentofu.org/assets/4549937/314e3595-6e11-44b6-9dc0-92b267d5c945">

After:
<img width="750" alt="Screenshot 2024-01-15 at 2 22 53 PM" src="https://github.com/opentofu/opentofu.org/assets/4549937/d29b35ee-9b77-4b4e-9feb-3ca7799fca08">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
