### PR TITLE
Fixes random routing errors, like here opentofu/opentofu#1116

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,6 +81,8 @@ const config: Config = {
   ],
 
   baseUrl: "/",
+  // For GitHub Pages, this value must be defined.
+  trailingSlash: false,
 
   // TODO: Once we clean up links we can switch to "throw"
   onBrokenLinks: "warn",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,7 +82,7 @@ const config: Config = {
 
   baseUrl: "/",
   // For GitHub Pages, this value must be defined.
-  trailingSlash: false,
+  trailingSlash: true,
 
   // TODO: Once we clean up links we can switch to "throw"
   onBrokenLinks: "warn",


### PR DESCRIPTION
Likely, this addresses the routing error that, in some cases, redirects to Error 404 when clicking on a link.

More details: https://github.com/opentofu/opentofu/issues/1116

The Docusaurus documentation suggests that this value should be either `true` or `false`. On the dev machine, links worked correctly when set to `false`.

Docs: https://docusaurus.io/docs/deployment#docusaurusconfigjs-settings