### PR TITLE
rearranged the order in which 4 subsections of documents appear

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,20 +13,6 @@ The documentation is divided into four main sections, covering CLI-based workflo
   items={[
     {
       type: "link",
-      href: "/docs/cli",
-      label: "CLI Documentation",
-      description:
-        "Learn OpenTofu's CLI-based workflows. You can use the CLI alone or with cloud backends.",
-    },
-    {
-      type: "link",
-      href: "/docs/internals",
-      label: "Internals",
-      description:
-        "Learn how OpenTofu generates the resource dependency graph and executes other internal processes.",
-    },
-    {
-      type: "link",
       href: "/docs/intro",
       label: "Intro",
       description:
@@ -34,10 +20,24 @@ The documentation is divided into four main sections, covering CLI-based workflo
     },
     {
       type: "link",
+      href: "/docs/cli",
+      label: "CLI Documentation",
+      description:
+        "Learn OpenTofu's CLI-based workflows. You can use the CLI alone or with cloud backends.",
+    },
+    {
+      type: "link",
       href: "/docs/language",
       label: "Language",
       description:
         "Use the OpenTofu configuration language to describe the infrastructure that OpenTofu manages.",
+    },
+    {
+      type: "link",
+      href: "/docs/internals",
+      label: "Internals",
+      description:
+        "Learn how OpenTofu generates the resource dependency graph and executes other internal processes.",
     },
   ]}
 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "website",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@docusaurus/core": "3.1.0",
         "@docusaurus/module-type-aliases": "3.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR will resolve #276 
## Description
<!--- Describe your changes in detail -->
The order in which the 4 subsections appeared in documents section of openTofu website was not intuitive. This PR rearranges those subsection to make the page look more organised
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
before:
![Screenshot 2024-03-04 at 1 51 50 PM](https://github.com/opentofu/opentofu.org/assets/75657887/54c1d53c-6d40-4364-9468-305a66594346)
After: 
![Screenshot 2024-03-04 at 4 27 23 PM](https://github.com/opentofu/opentofu.org/assets/75657887/1db509b2-ec81-4685-8038-6b92ed37d78b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
