### PR TITLE
remove .pages.dev links from blog posts

### DIFF
--- a/blog/2024-03-18-help-us-test-opentofu-1-7-0-alpha1.md
+++ b/blog/2024-03-18-help-us-test-opentofu-1-7-0-alpha1.md
@@ -33,7 +33,7 @@ For the releases above, please unpack the archive and you should find the `tofu`
 
 ## State encryption
 
-State encryption is one of the flagship features of this release. We have prepared a [full documentation](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/state/encryption/) for this feature.
+State encryption is one of the flagship features of this release. We have prepared a [full documentation](/docs/language/state/encryption/) for this feature.
 
 To test this feature, please make a backup of your state file and then add the following configuration:
 
@@ -79,7 +79,7 @@ terraform {
 }
 ```
 
-If you have access to an AWS account, you can also test the [AWS Key-Management Service](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/state/encryption/#aws-kms) key provider. (Please note the [AWS KMS pricing](https://aws.amazon.com/kms/pricing/).)
+If you have access to an AWS account, you can also test the [AWS Key-Management Service](/docs/language/state/encryption/#aws-kms) key provider. (Please note the [AWS KMS pricing](https://aws.amazon.com/kms/pricing/).)
 
 :::note
 The OpenTofu core developers would like to thank Stephan Bartels (Interhyp) and Alex Scheel for their extensive work on this feature.
@@ -87,7 +87,7 @@ The OpenTofu core developers would like to thank Stephan Bartels (Interhyp) and 
 
 ## Removed block
 
-The removed block lets you remove a resource from the state file but keep it on the infrastructure. We have prepared a [full documentation](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/resources/syntax/#removing-resources) for this feature. You can test it by creating a resource first:
+The removed block lets you remove a resource from the state file but keep it on the infrastructure. We have prepared a [full documentation](/docs/language/resources/syntax/#removing-resources) for this feature. You can test it by creating a resource first:
 
 ```hcl
 resource "local_file" "test" {
@@ -110,13 +110,13 @@ After the next apply, you will see that the local_file.test resource no longer e
 
 This release also contains several new functions and changes to existing functions:
 
-- New function: [templatestring](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatestring/)
-- New function: [base64gunzip](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/base64gunzip/)
-- New function: [cidrcontains](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/cidrcontains/)
-- New function: [urldecode](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/urldecode/)
-- New function: [issensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/issensitive/)
-- [nonsensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/nonsensitive/) no longer returns an error when the applied values are not sensitive.
-- [templatefile](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatefile/) now supports recursion up to a depth of 1024.
+- New function: [templatestring](/docs/language/functions/templatestring/)
+- New function: [base64gunzip](/docs/language/functions/base64gunzip/)
+- New function: [cidrcontains](/docs/language/functions/cidrcontains/)
+- New function: [urldecode](/docs/language/functions/urldecode/)
+- New function: [issensitive](/docs/language/functions/issensitive/)
+- [nonsensitive](/docs/language/functions/nonsensitive/) no longer returns an error when the applied values are not sensitive.
+- [templatefile](/docs/language/functions/templatefile/) now supports recursion up to a depth of 1024.
 
 ## CLI changes
 

--- a/blog/2024-04-18-opentofu-1-7-0-beta1.md
+++ b/blog/2024-04-18-opentofu-1-7-0-beta1.md
@@ -61,7 +61,7 @@ If you are interested in a detailed breakdown of this functionality and some of 
 
 ## Loopable import blocks
 
-We made several improvements to the declarative import blocks, most prominently you can now use the `for_each` instruction on the block. We have prepared a [full documentation](https://1-7-0-beta1.opentofu.pages.dev/docs/language/import/#importing-multiple-resources) for this feature.
+We made several improvements to the declarative import blocks, most prominently you can now use the `for_each` instruction on the block. We have prepared a [full documentation](/docs/language/import/#importing-multiple-resources) for this feature.
 
 In previous OpenTofu versions, you could already use the `import` block to declaratively import resources, for example:
 
@@ -109,7 +109,7 @@ The example above will let you specify some random IDs from a variable, and let 
 
 ## State encryption
 
-State encryption is one of the flagship features of this release. We have prepared a [full documentation](https://1-7-0-beta1.opentofu.pages.dev/docs/language/state/encryption/) for this feature. Since the alpha release we overhauled the migration process from unencrypted to encrypted state files and the rollback mechanism to make the syntax more explicit.
+State encryption is one of the flagship features of this release. We have prepared a [full documentation](/docs/language/state/encryption/) for this feature. Since the alpha release we overhauled the migration process from unencrypted to encrypted state files and the rollback mechanism to make the syntax more explicit.
 
 Before you test this feature, please **make a backup** of your state file. You can then add the following block to enable state encryption:
 
@@ -198,13 +198,13 @@ After the next apply, you will see that the `local_file.test` resource no longer
 
 This release also contains several new functions and changes to existing functions:
 
-- New function: [templatestring](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatestring/)
-- New function: [base64gunzip](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/base64gunzip/)
-- New function: [cidrcontains](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/cidrcontains/)
-- New function: [urldecode](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/urldecode/)
-- New function: [issensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/issensitive/)
-- [nonsensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/nonsensitive/) no longer returns an error when the applied values are not sensitive.
-- [templatefile](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatefile/) now supports recursion up to a depth of 1024.
+- New function: [templatestring](/docs/language/functions/templatestring/)
+- New function: [base64gunzip](/docs/language/functions/base64gunzip/)
+- New function: [cidrcontains](/docs/language/functions/cidrcontains/)
+- New function: [urldecode](/docs/language/functions/urldecode/)
+- New function: [issensitive](/docs/language/functions/issensitive/)
+- [nonsensitive](/docs/language/functions/nonsensitive/) no longer returns an error when the applied values are not sensitive.
+- [templatefile](/docs/language/functions/templatefile/) now supports recursion up to a depth of 1024.
 
 ## CLI changes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR changes hard-coded `.opentofu.pages.dev` links to relative ones in blog posts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We redirect people from `opentofu.org` to `.opentofu.pages.dev` and this PR makes links consistent across the blog posts.

## ~~Screenshots (if appropriate)~~:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
