### PR TITLE
Set both a light and a dark theme for code blocks

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -338,7 +338,8 @@ const config: Config = {
       ],
     },
     prism: {
-      theme: prismThemes.dracula,
+      theme: prismThemes.vsLight,
+      darkTheme: prismThemes.dracula,
       additionalLanguages: ["hcl", "powershell"],
     },
     image: "/img/og.png",


### PR DESCRIPTION
Fixes https://github.com/opentofu/opentofu.org/issues/304.

I arbitrarily chose `vsLight`; the list of available themes with the current dependencies is this, if anyone prefers something different:
```
dracula
duotoneDark
duotoneLight
github
jettwaveDark
jettwaveLight
nightOwl
nightOwlLight
oceanicNext
okaidia
oneDark
oneLight
palenight
shadesOfPurple
synthwave84
ultramin
vsDark
vsLight
```