### PR TITLE
Eliminate broken link warnings (except those from docs in the main repo)

### DIFF
--- a/blog/2023-10-10-opentofus-new-office-hours.mdx
+++ b/blog/2023-10-10-opentofus-new-office-hours.mdx
@@ -21,7 +21,7 @@ c_3f2dd3c1fe0ef4e93ef3fc456ca2dd219a2e8fd85f6b40750af16c3df370bf93@group.calenda
 import Button from "@site/src/components/Button";
 
 <Button
-  href="/OpenTofu-Events-Calendar.ics"
+  href="https://opentofu.org/OpenTofu-Events-Calendar.ics"
   variant="secondary"
   className="inline-flex"
   target="_blank"

--- a/blog/2023-12-19-opentofu-release-candidate-is-out.md
+++ b/blog/2023-12-19-opentofu-release-candidate-is-out.md
@@ -15,7 +15,7 @@ This release includes bug fixes, stability improvements, and updates to document
 
 ## From Idea to Release Candidate in 4 Months
 
-The OpenTofu journey has been a whirlwind, spanning from a proposition to a release candidate in just four months. 
+The OpenTofu journey has been a whirlwind, spanning from a proposition to a release candidate in just four months.
 
 This is a major milestone for us, but also a bittersweet moment. Looking back on the beginning of our journey, there was hope that HashiCorp [would hear our appeal](https://opentofu.org/manifesto), reverse its decision and restore balance to the ecosystem.
 
@@ -71,11 +71,11 @@ Outside of our own tests, the four most requested files were:
 - `/v1/providers/hashicorp/template/versions`
 - `/v1/providers/hashicorp/aws/versions`
 
-With the registry live, we set up a [GitHub Action](https://github.com/opentofu/registry/actions/workflows/bump-versions.yml) to scan for updates to indexed resources. We also introduced an [IssueOps process](https://github.com/opentofu/registry/commit/74bfbcf9435433c70c9f923a36aa9d0b16ec2f5a) for adding new providers. With it in place, new submissions would be auto-processed and auto-validated when they go into the registry, with Issues providing context and transparency. 
+With the registry live, we set up a [GitHub Action](https://github.com/opentofu/registry/actions/workflows/bump-versions.yml) to scan for updates to indexed resources. We also introduced an [IssueOps process](https://github.com/opentofu/registry/commit/74bfbcf9435433c70c9f923a36aa9d0b16ec2f5a) for adding new providers. With it in place, new submissions would be auto-processed and auto-validated when they go into the registry, with Issues providing context and transparency.
 
 ![A screenshot of the form allowing the addition of a new provider to the OpenTofu registry. The form fields are the provider name and DCO checkbox.](/img/blog/opentofu-release-candidate-is-out-issueops.png)
 
-We’re currently exploring a dedicated UI for package and documentation browsing. 
+We’re currently exploring a dedicated UI for package and documentation browsing.
 
 ## Next Stop: Jan 10th
 
@@ -92,5 +92,3 @@ While concluding the work on this post, and the upcoming release, we learned tha
 Mitchell’s work on projects such as Vagrant, Consul, Vault, and of course Terraform is a source of inspiration for us and many others within the Open Source community.
 
 The entire OpenTofu team extends its heartfelt gratitude to Mitchell for all of his numerous contributions, as we eagerly anticipate learning about the next steps in his already remarkable journey.
-
-

--- a/blog/2023-12-19-opentofu-release-candidate-is-out.md
+++ b/blog/2023-12-19-opentofu-release-candidate-is-out.md
@@ -81,7 +81,7 @@ We’re currently exploring a dedicated UI for package and documentation browsin
 
 With the holidays in full swing, we decided to roll out a release candidate first and schedule the GA for January 10th. Meanwhile, you can already start testing OpenTofu by simply following the [directions provided here](https://opentofu.org/docs/intro/install/). It is a drop-in replacement so Terraform users will feel right at home, which is the whole idea.
 
-If you are interested in contributing to the project, please check out these [contribution guidelines](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md), and don’t forget to join our [Slack community](/slack/).
+If you are interested in contributing to the project, please check out these [contribution guidelines](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md), and don’t forget to join our [Slack community](https://opentofu.org/slack/).
 
 Happy holidays!
 

--- a/blog/2024-03-18-help-us-test-opentofu-1-7-0-alpha1.md
+++ b/blog/2024-03-18-help-us-test-opentofu-1-7-0-alpha1.md
@@ -16,13 +16,12 @@ Do not test this release on a production project! It is not a stable release!
 
 :::
 
-
 ## Downloading the alpha release
 
 The alpha release is available exclusively from the [GitHub Releases page](https://github.com/opentofu/opentofu/releases/tag/v1.7.0-alpha1). Please select the appropriate file for your platform. Here are some quick links:
 
 | Platform/Device                                                                 | Download link                                                                                                                                       |
-|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Desktop Windows computer**<br />(64-bit)                                      | [tofu_1.7.0-alpha1_windows_amd64.zip](https://github.com/opentofu/opentofu/releases/download/v1.7.0-alpha1/tofu_1.7.0-alpha1_windows_amd64.zip)     |
 | **MacOS**<br />(Macbook M1 or higher; ARM64)                                    | [tofu_1.7.0-alpha1_darwin_arm64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.7.0-alpha1/tofu_1.7.0-alpha1_darwin_arm64.tar.gz) |
 | **MacOS**<br />(Macbook pre-M1 or lower; AMD64)                                 | [tofu_1.7.0-alpha1_darwin_amd64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.7.0-alpha1/tofu_1.7.0-alpha1_darwin_amd64.tar.gz) |

--- a/blog/2024-04-18-opentofu-1-7-0-beta1.md
+++ b/blog/2024-04-18-opentofu-1-7-0-beta1.md
@@ -19,7 +19,7 @@ Do not test this release on a production project! It is not a stable release!
 The beta release is available exclusively from the [GitHub Releases page](https://github.com/opentofu/opentofu/releases/tag/v1.7.0-beta1). Please select the appropriate file for your platform. Here are some quick links:
 
 | Platform/Device                                                                 | Download link                                                                                                                                    |
-|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Desktop Windows computer**<br />(64-bit)                                      | [tofu_1.7.0-beta1_windows_amd64.zip](https://github.com/opentofu/opentofu/releases/download/v1.7.0-beta1/tofu_1.7.0-beta1_windows_amd64.zip)     |
 | **MacOS**<br />(Macbook M1 or higher; ARM64)                                    | [tofu_1.7.0-beta1_darwin_arm64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.7.0-beta1/tofu_1.7.0-beta1_darwin_arm64.tar.gz) |
 | **MacOS**<br />(Macbook pre-M1 or lower; AMD64)                                 | [tofu_1.7.0-beta1_darwin_amd64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.7.0-beta1/tofu_1.7.0-beta1_darwin_amd64.tar.gz) |
@@ -55,7 +55,7 @@ output "test" {
 
 :::tip
 
-If you are interested in a detailed breakdown of this functionality and some of the new unique features OpenTofu brings in this area, [join our live stream on April 24](https://www.youtube.com/watch?v=6OXBv0MYalY). 
+If you are interested in a detailed breakdown of this functionality and some of the new unique features OpenTofu brings in this area, [join our live stream on April 24](https://www.youtube.com/watch?v=6OXBv0MYalY).
 
 :::
 
@@ -80,7 +80,7 @@ output "id" {
 }
 ```
 
-In this new version you can now also declaratively import resources in a loop: 
+In this new version you can now also declaratively import resources in a loop:
 
 ```hcl
 variable "server_ids" {
@@ -131,7 +131,7 @@ terraform {
 
     state {
       method = method.aes_gcm.my_method
-      
+
       ## Remove the fallback block after migration:
       fallback{
         method = method.unencrypted.migration

--- a/blog/2024-04-30-opentofu-1-7-0.md
+++ b/blog/2024-04-30-opentofu-1-7-0.md
@@ -1,13 +1,13 @@
 ---
-title: "OpenTofu 1.7.0 is out with State Encryption, Dynamic Provider-Defined Functions, and more" 
+title: "OpenTofu 1.7.0 is out with State Encryption, Dynamic Provider-Defined Functions, and more"
 slug: opentofu-1-7-0
 description: OpenTofu 1.7.0 is now available with full state encryption, dynamic provider-defined functions, the removed and loopable import blocks, new migration guides, and much more.
 image: /img/blog/opentofu-1-7-0.png
 ---
 
-In the last few months [since our first stable release](/blog/opentofu-is-going-ga/) the OpenTofu community and the core team have worked hand in hand to bring functionality to OpenTofu that has been requested for years.  We are proud to announce the immediate availability of [OpenTofu 1.7.0](https://github.com/opentofu/opentofu/releases/tag/v1.7.0), bringing you the following highlights:
+In the last few months [since our first stable release](/blog/opentofu-is-going-ga/) the OpenTofu community and the core team have worked hand in hand to bring functionality to OpenTofu that has been requested for years. We are proud to announce the immediate availability of [OpenTofu 1.7.0](https://github.com/opentofu/opentofu/releases/tag/v1.7.0), bringing you the following highlights:
 
-- [**End-to-end state encryption**](/docs/v1.7/intro/whats-new/#state-encryption) protects your state file from prying eyes, no matter what storage backend you use. You can provide your encryption passphrase securely using environment variables, or use a key management system such as AWS KMS, GCP KMS, or OpenBao. *This feature has been developed in collaboration with Stephan Bartels (Interhyp) and Alex Scheel from the OpenTofu community, whom we would like to thank for their work on this feature.*
+- [**End-to-end state encryption**](/docs/v1.7/intro/whats-new/#state-encryption) protects your state file from prying eyes, no matter what storage backend you use. You can provide your encryption passphrase securely using environment variables, or use a key management system such as AWS KMS, GCP KMS, or OpenBao. _This feature has been developed in collaboration with Stephan Bartels (Interhyp) and Alex Scheel from the OpenTofu community, whom we would like to thank for their work on this feature._
 - [**Dynamic provider-defined functions**](/docs/v1.7/intro/whats-new/#provider-defined-functions) let a provider not only provide resources, but also native functions you can use in your OpenTofu code. What's more, we added an OpenTofu-only feature to let providers dynamically define custom functions based on your configuration. This enhancement allows you to fully integrate other programming languages as [shown in our live stream](https://www.youtube.com/watch?v=6OXBv0MYalY). You can try out this functionality with our experimental [Lua](https://github.com/opentofu/terraform-provider-lua) and [Go](https://github.com/opentofu/terraform-provider-go) providers.
 - [**The removed block**](/docs/intro/whats-new/#removed-block) lets you mark OpenTofu-created resources for removal from the state file, but still keep the infrastructure you created.
 - [**Loopable import blocks**](/docs/intro/whats-new/#loopable-import-blocks) let you bulk-import resources declaratively in your OpenTofu code, helping with large-scale migrations.

--- a/blog/2024-04-30-opentofu-1-7-0.md
+++ b/blog/2024-04-30-opentofu-1-7-0.md
@@ -43,4 +43,4 @@ OpenTofu is first and foremost a community-driven project. We are looking forwar
 
 While much of OpenTofu 1.8 is still in planning, we are currently finalizing a proposal for a feature that lets you [use variables as module sources, backend configuration, and more](https://github.com/opentofu/opentofu/issues/1042). Early evaluation of variables has been requested in over 30 issues so far and is one of the most-requested features in OpenTofu.
 
-If you have a feature you would like to see in OpenTofu, please don't hesitate to [open an issue](https://github.com/opentofu/opentofu/issues/new/choose) or [reach out to us on Slack](/slack/).
+If you have a feature you would like to see in OpenTofu, please don't hesitate to [open an issue](https://github.com/opentofu/opentofu/issues/new/choose) or [reach out to us on Slack](https://opentofu.org/slack/).

--- a/blog/2024-06-24-help-us-test-opentofu-1-8-0-alpha1.md
+++ b/blog/2024-06-24-help-us-test-opentofu-1-8-0-alpha1.md
@@ -4,9 +4,9 @@ slug: help-us-test-opentofu-1-8-0-alpha1
 image: /img/blog/help-us-test-opentofu-1-8-0-alpha1.png
 ---
 
-Hey there, OpenTofu community! Since the last OpenTofu release we've been hard at work bringing you a much-needed improvement to the .tf language: the ability to **use variables in backends, module sources, and the encryption configuration** (*early variable/locals evaluation*). This is currently the [top-voted issue on the OpenTofu GitHub](https://github.com/opentofu/opentofu/issues/1496) and has, in various forms, been requested for years with OpenTofu's predecessor.
+Hey there, OpenTofu community! Since the last OpenTofu release we've been hard at work bringing you a much-needed improvement to the .tf language: the ability to **use variables in backends, module sources, and the encryption configuration** (_early variable/locals evaluation_). This is currently the [top-voted issue on the OpenTofu GitHub](https://github.com/opentofu/opentofu/issues/1496) and has, in various forms, been requested for years with OpenTofu's predecessor.
 
-Additionally, we are bringing you a feature that lets you use new OpenTofu features while still keeping compatibility with Terraform as well as the ability to override resources and data sources in `tofu test`. The release also includes a host of smaller improvements and bugfixes to various parts of OpenTofu [listed in the changelog](https://github.com/opentofu/opentofu/blob/main/CHANGELOG.md). 
+Additionally, we are bringing you a feature that lets you use new OpenTofu features while still keeping compatibility with Terraform as well as the ability to override resources and data sources in `tofu test`. The release also includes a host of smaller improvements and bugfixes to various parts of OpenTofu [listed in the changelog](https://github.com/opentofu/opentofu/blob/main/CHANGELOG.md).
 
 Now we'd like to ask you for help: we have done everything we could to make sure that the new alpha release doesn't break anything, and we need your help to get this release tested. If you have a **non-production** setup that you would be willing to test any of the new features on, please give it a try and give us [feedback using a GitHub issue](https://github.com/opentofu/opentofu/issues/new/choose), even if it's just telling us that everything went well.
 
@@ -18,13 +18,12 @@ Do not test this release on a production project! It is not a stable release!
 
 :::
 
-
 ## Downloading the alpha release
 
 The alpha release is available exclusively from the [GitHub Releases page](https://github.com/opentofu/opentofu/releases/tag/v1.8.0-alpha1). Please select the appropriate file for your platform. Here are some quick links:
 
 | Platform/Device                                                                 | Download link                                                                                                                                       |
-|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Desktop Windows computer**<br />(64-bit)                                      | [tofu_1.8.0-alpha1_windows_amd64.zip](https://github.com/opentofu/opentofu/releases/download/v1.8.0-alpha1/tofu_1.8.0-alpha1_windows_amd64.zip)     |
 | **MacOS**<br />(Macbook M1 or higher; ARM64)                                    | [tofu_1.8.0-alpha1_darwin_arm64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.8.0-alpha1/tofu_1.8.0-alpha1_darwin_arm64.tar.gz) |
 | **MacOS**<br />(Macbook pre-M1; AMD64)                                          | [tofu_1.8.0-alpha1_darwin_amd64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.8.0-alpha1/tofu_1.8.0-alpha1_darwin_amd64.tar.gz) |
@@ -37,7 +36,7 @@ For the releases above, please unpack the archive and you should find the `tofu`
 
 This feature lets you use variables and locals for **backends**, **module sources** and **encryption configuration** as long as they are not dependent on resources, data sources or module outputs. This works even if a local is referencing a variable, for example. This is only the first in a series of improvements that will make the .tf code more flexible with more improvements coming in future releases.
 
-The `tofu init` command will now consume your `.tfvars` file and let you specify variables using the `-var` and `-var-file` options. Please note that this alpha release will *not* prompt you for missing variables, which is a feature we will add later. Note, that `tofu init` will fail if it is missing variables needed for static evaluation.
+The `tofu init` command will now consume your `.tfvars` file and let you specify variables using the `-var` and `-var-file` options. Please note that this alpha release will _not_ prompt you for missing variables, which is a feature we will add later. Note, that `tofu init` will fail if it is missing variables needed for static evaluation.
 
 For example, if you wanted to use the same configuration for your S3 backend and your AWS provider, you can now do this:
 
@@ -173,4 +172,3 @@ While this will not fully test the entire provisioning, it will highlight errors
 ## Providing feedback
 
 Thank you for taking the time to test this preview release. If you have any feedback, please use [a GitHub issue](https://github.com/opentofu/opentofu/issues/new/choose) or chat with us on the [OpenTofu Slack](https://opentofu.org/slack/).
-

--- a/blog/2024-07-09-opentofu-1-8-0-beta-1.md
+++ b/blog/2024-07-09-opentofu-1-8-0-beta-1.md
@@ -27,7 +27,7 @@ On 2024/07/11, 1.8.0-beta2 was released to address issues present in 1.8.0-beta1
 The beta release is available exclusively from the [GitHub Releases page](https://github.com/opentofu/opentofu/releases/tag/v1.8.0-beta2). Please select the appropriate file for your platform. Here are some quick links:
 
 | Platform/Device                                                                 | Download link                                                                                                                                    |
-|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Desktop Windows computer**<br />(64-bit)                                      | [tofu_1.8.0-beta2_windows_amd64.zip](https://github.com/opentofu/opentofu/releases/download/v1.8.0-beta2/tofu_1.8.0-beta2_windows_amd64.zip)     |
 | **MacOS**<br />(Macbook M1 or higher; ARM64)                                    | [tofu_1.8.0-beta2_darwin_arm64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.8.0-beta2/tofu_1.8.0-beta2_darwin_arm64.tar.gz) |
 | **MacOS**<br />(Macbook pre-M1; AMD64)                                          | [tofu_1.8.0-beta2_darwin_amd64.tar.gz](https://github.com/opentofu/opentofu/releases/download/v1.8.0-beta2/tofu_1.8.0-beta2_darwin_amd64.tar.gz) |
@@ -61,6 +61,7 @@ resource "aws_instance" "web" {
 ```
 
 Instead of querying the AMI ID and spinning up the instance, we can write test code as follows:
+
 ```hcl
 // This block will prevent OpenTofu from configuring aws provider.
 // All provider's resources and data sources will be mocked.
@@ -150,7 +151,7 @@ While this will not fully test the entire provisioning, it will highlight errors
 
 Introduced in OpenTofu 1.8.0-alpha1, this feature lets you use variables and locals for **backends**, **module sources** and **encryption configuration** as long as they are not dependent on resources, data sources or module outputs. This works even if a local is referencing a variable, for example. This is only the first in a series of improvements that will make the .tf code more flexible with more improvements coming in future releases.
 
-The `tofu init` command will now consume your `.tfvars` file and let you specify variables using the `-var` and `-var-file` options. Please note that this alpha release will *not* prompt you for missing variables, which is a feature we will add later. Note, that `tofu init` will fail if it is missing variables needed for static evaluation.
+The `tofu init` command will now consume your `.tfvars` file and let you specify variables using the `-var` and `-var-file` options. Please note that this alpha release will _not_ prompt you for missing variables, which is a feature we will add later. Note, that `tofu init` will fail if it is missing variables needed for static evaluation.
 
 For example, if you wanted to use the same configuration for your S3 backend and your AWS provider, you can now do this:
 
@@ -224,6 +225,7 @@ Since we are now adding features to OpenTofu that are not present in Terraform, 
 ### Static Variable Planing
 
 Static variables are now handled correctly when embedded in plan files. This was [reported as a bug](https://github.com/opentofu/opentofu/issues/1768) found in 1.8.0-alpha1.
+
 ```bash
 tofu plan -out=tofu.tfstate -var="param=value"
 # Variables are correctly read from the given plan and should not be specified via CLI
@@ -238,10 +240,10 @@ Also included in the beta is [improvements in error messages produced by misconf
 ```
 ╷
 │ Error: Insufficient features blocks
-│ 
+│
 │   on <empty> line 0:
 │   (source code not available)
-│ 
+│
 │ At least 1 "features" blocks are required.
 ╵
 ```
@@ -251,4 +253,3 @@ This error message will now include information about which provider is encounte
 ## Providing feedback
 
 Thank you for taking the time to test this preview release. If you have any feedback, please use [a GitHub issue](https://github.com/opentofu/opentofu/issues/new/choose) or chat with us on the [OpenTofu Slack](https://opentofu.org/slack/).
-

--- a/blog/2024-07-29-opentofu-1-8-0.md
+++ b/blog/2024-07-29-opentofu-1-8-0.md
@@ -5,7 +5,7 @@ description: OpenTofu 1.8.0 is now available with early variable/locals evaluati
 image: /img/blog/opentofu-1.8.0.png
 ---
 
-Since the [1.7 release](/blog/opentofu-1.7.0), the OpenTofu community and core team have been hard at work on much-requested features, making `.tf` code easier to write, reducing unnecessary boilerplate, improving performance, and more. We are happy to announce the [immediate availability of OpenTofu 1.8](https://github.com/opentofu/opentofu/releases/tag/v1.8.0) with the following main features:
+Since the [1.7 release](/blog/opentofu-1-7-0), the OpenTofu community and core team have been hard at work on much-requested features, making `.tf` code easier to write, reducing unnecessary boilerplate, improving performance, and more. We are happy to announce the [immediate availability of OpenTofu 1.8](https://github.com/opentofu/opentofu/releases/tag/v1.8.0) with the following main features:
 
 - [You can now use variables and locals in places](/docs/intro/whats-new/#early-variablelocals-evaluation) that were not previously available, such as module sources, backend configuration and state encryption. Being able to assign variables more dynamically will eliminate code duplication and boilerplate code, making projects easier to maintain. However, we are not stopping there: future releases will see [dynamic provider configuration assignments](https://github.com/opentofu/opentofu/issues/300) and more.
 - Since Terraform doesn't support these new language features, [OpenTofu now supports the `.tofu` file extension](/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility). When a file with the `.tofu` extension is present, OpenTofu will ignore the identically named `.tf` file. Using this new file extension, module authors can use the new features of OpenTofu and still keep older code around for compatibility.
@@ -15,7 +15,7 @@ You can find the full list of improvements and changes on the [What's new in Ope
 
 ## Growth continues: ~30% increase in registry traffic
 
-While we don't believe in tracking our users and OpenTofu does not have phone-home telemetry, we can observe a trajectory based on registry usage. In our [last release post](/blog/opentofu-1.7.0) 3 months ago we recorded a peak of roughly 1.4 million daily requests to the registry. We are happy to report that this number has increased by roughly 30% to almost 1.8 million peak daily requests.
+While we don't believe in tracking our users and OpenTofu does not have phone-home telemetry, we can observe a trajectory based on registry usage. In our [last release post](/blog/opentofu-1-7-0) 3 months ago we recorded a peak of roughly 1.4 million daily requests to the registry. We are happy to report that this number has increased by roughly 30% to almost 1.8 million peak daily requests.
 
 ![A graph showing the OpenTofu registry requests per day.](/img/blog/opentofu-registry-july-2024.svg)
 

--- a/blog/2024-07-29-opentofu-1-8-0.md
+++ b/blog/2024-07-29-opentofu-1-8-0.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTofu 1.8.0 is out with Early Evaluation, Provider Mocking, and a Coder-Friendly Future 
+title: OpenTofu 1.8.0 is out with Early Evaluation, Provider Mocking, and a Coder-Friendly Future
 slug: opentofu-1-8-0
 description: OpenTofu 1.8.0 is now available with early variable/locals evaluation, provider mocking for tests, and a future that makes every-day Tofu code a lot simpler.
 image: /img/blog/opentofu-1.8.0.png
@@ -9,7 +9,7 @@ Since the [1.7 release](/blog/opentofu-1.7.0), the OpenTofu community and core t
 
 - [You can now use variables and locals in places](/docs/intro/whats-new/#early-variablelocals-evaluation) that were not previously available, such as module sources, backend configuration and state encryption. Being able to assign variables more dynamically will eliminate code duplication and boilerplate code, making projects easier to maintain. However, we are not stopping there: future releases will see [dynamic provider configuration assignments](https://github.com/opentofu/opentofu/issues/300) and more.
 - Since Terraform doesn't support these new language features, [OpenTofu now supports the `.tofu` file extension](/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility). When a file with the `.tofu` extension is present, OpenTofu will ignore the identically named `.tf` file. Using this new file extension, module authors can use the new features of OpenTofu and still keep older code around for compatibility.
-- You can now use [provider mocking](/docs/intro/whats-new/#provider-mocking-in-tofu-test) as well as [resource overrides]( /docs/intro/whats-new/#resource-overrides-in-tofu-test) with `tofu test`. This allows for more flexible testing similar to traditional software testing methods.
+- You can now use [provider mocking](/docs/intro/whats-new/#provider-mocking-in-tofu-test) as well as [resource overrides](/docs/intro/whats-new/#resource-overrides-in-tofu-test) with `tofu test`. This allows for more flexible testing similar to traditional software testing methods.
 
 You can find the full list of improvements and changes on the [What's new in OpenTofu 1.8?](/docs/intro/whats-new/) page.
 
@@ -47,7 +47,7 @@ Please give these libraries a go (pun totally intended) and let us know what fun
 
 ## The future: more dynamic functionality, even more community-focussed development
 
-Ever since we created our [top-ranking issues](https://github.com/opentofu/opentofu/issues/1496) list, new votes from the community started pouring in, giving us a strong signal on where you want us to take OpenTofu. By a large margin, the top-requested issue was one we partly solved in this release by introducing early evaluation for variables and locals. However, this is only the first step. As you helped us test the early alpha and beta of this release, one of the most commonly asked questions was: *“When can I use early evaluation to dynamically configure providers?”*
+Ever since we created our [top-ranking issues](https://github.com/opentofu/opentofu/issues/1496) list, new votes from the community started pouring in, giving us a strong signal on where you want us to take OpenTofu. By a large margin, the top-requested issue was one we partly solved in this release by introducing early evaluation for variables and locals. However, this is only the first step. As you helped us test the early alpha and beta of this release, one of the most commonly asked questions was: _“When can I use early evaluation to dynamically configure providers?”_
 
 The top-voted enhancement reflects a similar sentiment. In 1.9 and beyond, we aim to bring you dynamic provider assignments and more early-evaluation features, which let you cut down on the unnecessary code repetition even further. If you are interested in this topic, give the [corresponding RFC a read](https://github.com/opentofu/opentofu/blob/main/rfc/20240513-static-evaluation-providers.md).
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -330,7 +330,7 @@ const config: Config = {
         },
         {
           type: "custom-social-icon-link-navbar-item",
-          href: "/slack",
+          href: "https://opentofu.org/slack/",
           position: "right",
           name: "slack",
           label: "Join us on Slack",

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -66,7 +66,7 @@ export default function Footer({ links }: FooterProps) {
           />
           <SocialIconLink
             name="slack"
-            href="/slack"
+            href="https://opentofu.org/slack/"
             label="Join us on Slack"
             hiddenLabel
           />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Partial fix for the current "broken link" warnings, to unblock https://github.com/opentofu/opentofu.org/issues/85.

For a complete fix, separate PRs will be needed to the four branches of the main https://github.com/opentofu/opentofu repo, as there are also some broken links in each of these. Then the submodule references will need updating, and then all should be well.

Initial draft for that `main` branch is here: https://github.com/opentofu/opentofu/pull/1884/files

Fair warning in advance: once all the broken links are fixed, Docusaurus reveals further warnings about broken anchors. (The setting defaulting to `warn` for these is separate from that for the links.) But this is progress, at least.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change depends on a change (four changes) in the main [opentofu repository](https://github.com/opentofu/opentofu).
