### PR TITLE
Remove OpenTF reference

### DIFF
--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -33,7 +33,7 @@ export default function Hero() {
         The open source infrastructure as code tool.
       </Headline>
       <p className="my-6 text-xl sm:max-w-lg md:max-w-xl lg:max-w-2xl text-center text-gray-600 dark:text-gray-500">
-        Previously named OpenTF, OpenTofu is a fork of Terraform that is
+        OpenTofu is a fork of Terraform that is
         open-source, community-driven, and managed by the Linux Foundation.
       </p>
 


### PR DESCRIPTION


## Description
OpenTofu has not been called OpenTF for awhile and is probably not necessary to point out in the hero.

## Motivation and Context
Just seems like not a great use of space at this point.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
