### PR TITLE
Fix slack link

### DIFF
--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="refresh"
-      content="0; url=https://join.slack.com/t/opentofucommunity/shared_invite/zt-2otsbzyjn-dNMHY2i1cjtR2rgoBej3lg"
+      content="0; url=https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A"
     />
     <link
       rel="canonical"
-      href="https://join.slack.com/t/opentofucommunity/shared_invite/zt-2otsbzyjn-dNMHY2i1cjtR2rgoBej3lg"
+      href="https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A"
     />
   </head>
   <script>
     window.location.href =
-      "https://join.slack.com/t/opentofucommunity/shared_invite/zt-2otsbzyjn-dNMHY2i1cjtR2rgoBej3lg";
+      "https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A";
   </script>
 </html>


### PR DESCRIPTION
Somehow slack removed our "forever" link I created last time...
