### PR TITLE
Add IAC Gradle Plugin Suite

### DIFF
--- a/supporters.json
+++ b/supporters.json
@@ -929,6 +929,12 @@
     "type": "Company",
     "pledge": "Minor Development; Testing; open-source community efforts"
   },
+    {
+    "name": "IAC Gradle Plugin Suite",
+    "url": "https://iac-gradle.ysb33r.org/",
+    "type": "Project",
+    "pledge": "Development; Testing; open-source community efforts"
+  },
   {
     "name": "OTF",
     "url": "https://github.com/leg100/otf",


### PR DESCRIPTION
Describes the IAC Gradle plugin suite's support of OpenTofu

## Motivation and Context

We have been integrating Terraform with Gradle for a number of years.
Now we have finally got the time to properly support OpenTofu as well, with a feature set on par with what the Terraform plugins provide.

(If this change to `supporters.json` is inappropriate, jsut throw this PR away).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Docs update.


