### PR TITLE
Update the invite link for the Slack community

### DIFF
--- a/static/slack/index.html
+++ b/static/slack/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="refresh"
-      content="0; url=https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A"
+      content="0; url=https://join.slack.com/t/opentofucommunity/shared_invite/zt-2zhebutd3-UObjBsVSK1jSNiSeJ2iQOA"
     />
     <link
       rel="canonical"
-      href="https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A"
+      href="https://join.slack.com/t/opentofucommunity/shared_invite/zt-2zhebutd3-UObjBsVSK1jSNiSeJ2iQOA"
     />
   </head>
   <script>
     window.location.href =
-      "https://join.slack.com/t/opentofucommunity/shared_invite/zt-2z21gw7qp-8PD1VG58ckZinXOjsYGU3A";
+      "https://join.slack.com/t/opentofucommunity/shared_invite/zt-2zhebutd3-UObjBsVSK1jSNiSeJ2iQOA";
   </script>
 </html>


### PR DESCRIPTION
We seem to have depleted the previous one. We'll need to find a better solution than manually updating this every few days, but this is just to buy us a few more days to figure that out.
