### PR TITLE
change announcement and links for 1.10 alpha2 blog post

### DIFF
--- a/blog/2025-04-25-help-us-test-opentofu-1-10-0-alpha2.md
+++ b/blog/2025-04-25-help-us-test-opentofu-1-10-0-alpha2.md
@@ -125,7 +125,7 @@ output "examle" {
 }
 ```
 
-For more information, see [marking variable as deprecated](https://1-10-0-alpha2-blog.opentofu.pages.dev/docs/main/language/values/variables/#marking-variable-as-deprecated) and [marking output as deprecated](https://1-10-0-alpha2-blog.opentofu.pages.dev/docs/main/language/values/outputs/#deprecated--marking-output-as-deprecated)
+For more information, see [marking variable as deprecated](https://opentofu.org/docs/main/language/values/variables/#marking-variable-as-deprecated) and [marking output as deprecated](https://opentofu.org/docs/main/language/values/outputs/#deprecated--marking-output-as-deprecated)
 
 ### Global Provider Cache Locking
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -212,7 +212,7 @@ const config: Config = {
     announcementBar: {
       id: "opentofu-ga",
       content:
-        'OpenTofu 1.10.0-alpha1 is released! <a href="/blog/help-us-test-opentofu-1-10-0-alpha1/">Check it out here.</a>',
+        'Help us test OpenTofu 1.10.0-alpha2! <a href="/blog/help-us-test-opentofu-1-10-0-alpha2/">Check it out here.</a>',
       backgroundColor: "#ffda18",
       textColor: "#1b1d20",
       isCloseable: false,


### PR DESCRIPTION
This PR updates the announcement bar and changes the blog post links to point to opentofu.org dev docs.