### PR TITLE
blog/opentofu-1-10-0-beta1: More clarity on OCI Registry Support

### DIFF
--- a/blog/2025-05-19-help-us-test-opentofu-1-10-0-beta1.md
+++ b/blog/2025-05-19-help-us-test-opentofu-1-10-0-beta1.md
@@ -72,20 +72,26 @@ If this is your first look at OpenTofu 1.10.0, here's a concise overview of the 
 
 Full integration with OCI registries for both provider and module distribution, valuable for organizations with private infrastructure-as-code components, air-gapped environments, or enhanced security requirements.
 
+Use module packages from OCI registries directly as a new [module source type](/docs/language/modules/sources/):
+
 ```hcl
-# Configure OCI registry mirrors in your CLI configuration:
+module "vpc" {
+  source = "oci://example.com/modules/vpc/aws"
+}
+```
+
+Configure OCI registry provider mirrors in your [CLI configuration](/docs/cli/config/config-file):
+
+```hcl
 provider_installation {
   oci_mirror {
     repository_template = "example.com/opentofu-providers/${namespace}/${type}"
     include             = ["registry.opentofu.org/*/*"]
   }
 }
-
-# Use OCI modules directly in your configuration:
-module "vpc" {
-  source = "oci://example.com/modules/vpc/aws"
-}
 ```
+
+You can find more information on OpenTofu's OCI artifact formats, and instructions for building your own artifacts, in [OCI Registry Integrations](/docs/main/cli/oci_registries/).
 
 ### Native S3 Locking
 


### PR DESCRIPTION
The original version of this showed some code examples without must context on how to make use of them. This new version links to relevant documentation to try to help put these examples in context, so it's hopefully easier to figure out how and where to use them.

I also made the editorial decision to show the module call example before the provider mirror example just because far more people write their own modules than want to create mirrors of providers, and so it seems likely that the module package support will be of broader interest.

---

Since the "OCI Registry Integrations" documentation content is currently only on the `main` branch this links to the "Development" version of the docs, which is a little awkward since that URL style is a moving target that'll start to represent the v1.11 development work at some point, but I don't have a better idea for now... maybe we can retroactively update this to link to a "normal" docs URL once v1.10.0 final is out. :thinking: 

(In the long run it would be nice for the "main" URL style to be named after whatever release we're currently developing on that branch so that the meaning of these URLs doesn't change throughout development, but that's well beyond the scope of this PR!)
