### PR TITLE
Add additional languages dropped by docusarus 2-3 upgrade

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 import tailwind from "tailwindcss";
 import autoprefixer from "autoprefixer";
 
+
 const config: Config = {
   title: "OpenTofu",
   url: "https://opentofu.org",
@@ -351,7 +352,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.oneLight,
       darkTheme: prismThemes.oneDark,
-      additionalLanguages: ["hcl", "powershell", "bash"],
+      additionalLanguages: ["hcl", "powershell", "bash", "json", "diff", "docker", "shell-session"],
     },
     image: "/img/og.png",
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
Encountered when working on https://github.com/opentofu/opentofu/pull/3868

Discovered the full list with:
```shell
grep '```' opentofu-repo/main/website/ -r | tr ":" " " | awk '{print $2}' | grep -v '`\s*$' | grep '`' |sort | uniq
```