### PR TITLE
Fix edit URL link for current version

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,7 +4,6 @@ import type * as Preset from "@docusaurus/preset-classic";
 import tailwind from "tailwindcss";
 import autoprefixer from "autoprefixer";
 
-
 const config: Config = {
   title: "OpenTofu",
   url: "https://opentofu.org",
@@ -148,13 +147,9 @@ const config: Config = {
           },
           routeBasePath: "/docs",
           editUrl: ({ version, docPath }) => {
-            // Remove the edit link from the documentation index page
-            // TODO: remove after moving the page to the main OpenTofu repo
-            if (docPath === "index.mdx") {
-              return `https://github.com/opentofu/opentofu.org/edit/${version}/docs/${docPath}`;
-            }
+            const branch = version == "current" ? "main" : version;
 
-            return `https://github.com/opentofu/opentofu/edit/${version}/website/docs/${docPath}`;
+            return `https://github.com/opentofu/opentofu/edit/${branch}/website/docs/${docPath}`;
           },
         },
       } satisfies Preset.Options,
@@ -224,7 +219,7 @@ const config: Config = {
     announcementBar: {
       id: "opentofu-1-11-ga",
       content:
-      '<a href="/blog/opentofu-1-11-0/" class="announcement-bar-link"><div class="announcement-bar-content">🎉 OpenTofu 1.11.0 has arrived! <span class="announcement-arrow">→</span></div></a>',
+        '<a href="/blog/opentofu-1-11-0/" class="announcement-bar-link"><div class="announcement-bar-content">🎉 OpenTofu 1.11.0 has arrived! <span class="announcement-arrow">→</span></div></a>',
       backgroundColor: "#00000000",
       isCloseable: false,
     },
@@ -352,7 +347,15 @@ const config: Config = {
     prism: {
       theme: prismThemes.oneLight,
       darkTheme: prismThemes.oneDark,
-      additionalLanguages: ["hcl", "powershell", "bash", "json", "diff", "docker", "shell-session"],
+      additionalLanguages: [
+        "hcl",
+        "powershell",
+        "bash",
+        "json",
+        "diff",
+        "docker",
+        "shell-session",
+      ],
     },
     image: "/img/og.png",
   } satisfies Preset.ThemeConfig,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 import tailwind from "tailwindcss";
 import autoprefixer from "autoprefixer";
 
+
 const config: Config = {
   title: "OpenTofu",
   url: "https://opentofu.org",
@@ -147,7 +148,7 @@ const config: Config = {
           },
           routeBasePath: "/docs",
           editUrl: ({ version, docPath }) => {
-            const branch = version == "current" ? "main" : version;
+            const branch = version == "current" ? "v1.11" : version;
 
             return `https://github.com/opentofu/opentofu/edit/${branch}/website/docs/${docPath}`;
           },
@@ -219,7 +220,7 @@ const config: Config = {
     announcementBar: {
       id: "opentofu-1-11-ga",
       content:
-        '<a href="/blog/opentofu-1-11-0/" class="announcement-bar-link"><div class="announcement-bar-content">🎉 OpenTofu 1.11.0 has arrived! <span class="announcement-arrow">→</span></div></a>',
+      '<a href="/blog/opentofu-1-11-0/" class="announcement-bar-link"><div class="announcement-bar-content">🎉 OpenTofu 1.11.0 has arrived! <span class="announcement-arrow">→</span></div></a>',
       backgroundColor: "#00000000",
       isCloseable: false,
     },
@@ -347,15 +348,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.oneLight,
       darkTheme: prismThemes.oneDark,
-      additionalLanguages: [
-        "hcl",
-        "powershell",
-        "bash",
-        "json",
-        "diff",
-        "docker",
-        "shell-session",
-      ],
+      additionalLanguages: ["hcl", "powershell", "bash", "json", "diff", "docker", "shell-session"],
     },
     image: "/img/og.png",
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
## Description
This changes the editUrl link for the 'current' version when not selecting a specific version in the Docs drop-down.
The previous link did not lead to a valid GitHub branch. It now links to the latest versioned release (v1.11 as of now).

Additionally the special case for the index.mdx file was removed. This was an outstanding ToDo which was also broken and now works correctly.

## Motivation and Context
Resolves #416 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
