### PR TITLE
replace static current branch name with latest from versions list

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import tailwind from "tailwindcss";
 import autoprefixer from "autoprefixer";
-
+import versions from "./versions.json";
 
 const config: Config = {
   title: "OpenTofu",
@@ -148,7 +148,7 @@ const config: Config = {
           },
           routeBasePath: "/docs",
           editUrl: ({ version, docPath }) => {
-            const branch = version == "current" ? "v1.11" : version;
+            const branch = version == "current" ? versions[0] : version;
 
             return `https://github.com/opentofu/opentofu/edit/${branch}/website/docs/${docPath}`;
           },


### PR DESCRIPTION
## Description
This changes the hard-coded current version introduced in https://github.com/opentofu/opentofu.org/pull/417
After merging further comments about the static version check were raised. This resolved this, by using the existing list from versions.json. AFAIK this has to be maintained for the versioned docs and is therefore a valid source for the latest/current version.

## Motivation and Context

Easier maintenance when adding a new version.

## Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change depends on a change in the main [opentofu repository](https://github.com/opentofu/opentofu).
