### PR TITLE
The main "docs" symlink should be to v1.12 now

### DIFF
--- a/docs
+++ b/docs
@@ -1,1 +1,1 @@
-opentofu-repo/v1.11/website/docs/
+opentofu-repo/v1.12/website/docs


### PR DESCRIPTION
It seems like we missed this when doing the v1.12.0 release, so the website continued using the v1.11 series docs as the default for unversioned URLs.
